### PR TITLE
ci(travis): Run build script to each job in the Stage Image stage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install: true
 
 stages:
   - name: Build
+    if: branch = staging AND type = pull
   - name: Stage Image
     if: branch = staging AND type = push
 
@@ -53,6 +54,7 @@ jobs:
         - DOCKER_PUBLIC_IMAGE_NAME=$DOCKER_STAGE_IMAGE_NAME
         - TAG=latest
       script:
+        - ./sh/ci/build.sh
         - ./sh/ci/deploy.sh
         - ./sh/ci/test-deploy.sh
 
@@ -61,6 +63,7 @@ jobs:
         - DOCKER_PUBLIC_IMAGE_NAME=$DOCKER_STAGE_IMAGE_NAME
         - TAG=alpine-edge
       script:
+        - ./sh/ci/build.sh
         - ./sh/ci/deploy.sh
         - ./sh/ci/test-deploy.sh
 
@@ -69,5 +72,6 @@ jobs:
         - DOCKER_PUBLIC_IMAGE_NAME=$DOCKER_STAGE_IMAGE_NAME
         - TAG=alpine-3.5
       script:
+        - ./sh/ci/build.sh
         - ./sh/ci/deploy.sh
         - ./sh/ci/test-deploy.sh


### PR DESCRIPTION
Travis does not share files between stages. This includes locally built/tagged Docker images. In order to push an image, we must also build it in the same stage.